### PR TITLE
Fixed Windows paths handling for paths with ':'.

### DIFF
--- a/RelativePath.Example1.php
+++ b/RelativePath.Example1.php
@@ -15,7 +15,8 @@ if (!empty($_POST['path'])) {
 	"../../../home/./John Doe/work/site/test/../../www/Project.1/" . "/../Project.2/index.html",
 	"./././../../../../../../../../../home/./John Doe/work/site/test/../../www/Project.1" . "/" . "../Project.2/index.html",
 	"../../home/../../../John Doe/work/site/test/../../www/Project.1" . "/" . "../Project.2/index.html/../",
-	"/media/Projects/www/test/images/../../home/../../../John Doe/work/site/test.2/../../www/Project.1");
+	"/media/Projects/www/test/images/../../home/../../../John Doe/work/site/test.2/../../www/Project.1",
+	"c:\\Windows\\..\\Temp\\tempfile.txt");
 }
 
 /**

--- a/RelativePath.php
+++ b/RelativePath.php
@@ -57,7 +57,7 @@ class RelativePath {
         if (empty($dirs[0])) {
             $root = "/";
             $dirs = array_splice($dirs, 1);
-        } else if (preg_match("#[A-Za-z]:#", $dirs[0])) {
+        } else if (preg_match("#^[A-Za-z]:$#", $dirs[0])) {
             $root = strtoupper($dirs[0]) . "/";
             $dirs = array_splice($dirs, 1);
         } 


### PR DESCRIPTION
@egilli's never-merged original pull request from @grandt's repo:

> A path with a colon is not necessarily a Windows
> path.


Merging into xss patched version.